### PR TITLE
Added missing .babelrc. Without it, JSX couldn't get transformed.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,7 @@
+{
+    "plugins": [
+        "transform-object-rest-spread",
+        "transform-react-jsx",
+        "transform-runtime",
+    ]
+}


### PR DESCRIPTION
I've tried to compile but got errors because of the JSX syntax inside of `block.js` and `sidebar.js`. For me it looked like Babel presets for React were missing. Then I saw these `babel-plugin-transform-*` dependencies in `package.json` and just added them to a `.babelrc` file and it seem to work.